### PR TITLE
Do not run CI on Julia v1.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
           - '1.9'
           - 'nightly'
         os:


### PR DESCRIPTION
Because the package declares that it is runnable only on Julia v1.9.0+, we should not attempt to run tests with Julia v1.0.